### PR TITLE
fix: cron schedule

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,7 +5,7 @@ on:
     # "At 06:00 on the first Wednesday of every month" UTC
     # i.e. 7 am CET or 8 am CEST
     # https://crontab.guru/#0_6_1-7_*_*/3
-    - cron: 0 6 1-7 * */3
+    - cron: '0 6 1-7 * */3'
 
 jobs:
   update:


### PR DESCRIPTION
this schedule triggered unexpectedly again.

i'm now grasping for straws.

but GitHub tells me to use https://crontab.guru/#0_6_1-7_*_*/3, which confirms that this is correct.

all examples use quotes, so let me try that.